### PR TITLE
Allow for more permissive CORS behaviour in non production environments

### DIFF
--- a/packages/remix-serve/index.ts
+++ b/packages/remix-serve/index.ts
@@ -7,7 +7,18 @@ export function createApp(buildPath: string, mode = "production") {
   let app = express();
 
   app.disable("x-powered-by");
-
+  
+  if (mode !== "production") {
+    app.use(function (req, res, next) {
+      res.header("Access-Control-Allow-Origin", "*");
+      res.header(
+        "Access-Control-Allow-Headers",
+        "Origin, X-Requested-With, Content-Type, Accept"
+      );
+      next();
+    });
+  }
+  
   app.use(compression());
 
   app.use(


### PR DESCRIPTION
This PR Is more of a suggestion / discussion point.

When using the default RemixAppServer as a development server I hit CORS issues on the statically served files from the `public` folder, where there is no way to set more permissive CORS headers. This change would allows RemixAppServer to continue to be used in development in my case, where I'm accessing the served page in and `<iframe sandbox="allow-scripts" />'.

Should we have permissive CORS headers added in development by default?
